### PR TITLE
Non matching cards fix

### DIFF
--- a/lib/cardstatistics.js
+++ b/lib/cardstatistics.js
@@ -87,6 +87,8 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 			}
 
 			data.estimate += estimate;
+		} else {
+			console.log("Card '" + card.name + "' doesn't have a correct estimate specification.");
 		}
 	}
 	callback(null, data);

--- a/lib/cardstatistics.js
+++ b/lib/cardstatistics.js
@@ -33,8 +33,8 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 		var title = card.name;
 		var matches = reg.exec(title);
 
-		if (matches.length > 1) {
-			var prio = matches[1];		
+		if (matches && matches.length > 1) {
+			var prio = matches[1];
 			var estimate = parseFloat(matches[2]);
 			var effort = parseFloat(matches[3]);
 			var isCardFinished = false;
@@ -42,7 +42,7 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 			if (card.actions) {
 				for (var idxActions = 0; idxActions < card.actions.length; idxActions++) {
 					if (card.actions[idxActions]) {
-						if (card.actions[idxActions].data.listAfter 
+						if (card.actions[idxActions].data.listAfter
 							&& card.actions[idxActions].data.listBefore
 							&& (card.actions[idxActions].data.listBefore.name !== card.actions[idxActions].data.listAfter.name)
 							&& ((!finishLists.length && finishLists === card.actions[idxActions].data.listAfter.name) || finishLists.indexOf(card.actions[idxActions].data.listAfter.name) > -1 )) {
@@ -56,7 +56,7 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 								var found = false;
 								for (var idxEffort = 0; idxEffort < data.effort.length; idxEffort++) {
 									if (Date.parse(data.effort[idxEffort].date) === Date.parse(cleanDate)) {
-										data.effort[idxEffort].estimate += estimate;										
+										data.effort[idxEffort].estimate += estimate;
 										data.effort[idxEffort].effort += effort;
 										found = true;
 									}
@@ -95,7 +95,7 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 function getRelatingDay(date, standuptime) {
 	if (standuptime) {
 		var standup = new Date(date.getFullYear(), date.getMonth(), date.getDate(), standuptime.getHours(), standuptime.getMinutes(), 0);
-		
+
 		if (Date.parse(date) <= Date.parse(standup)) {
 			var returnDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
 			returnDate = new Date(returnDate.setDate(returnDate.getDate() - 1));
@@ -131,14 +131,14 @@ CardStatistics.prototype.export = function(data, resources, days, name, callback
 
 		if (!effortContent.length) {
 			statsData[date] = { day: date, date: dateToReceive, totalEstimate: data.estimate, idealEstimate: data.estimate - (averageDayEffort * plannedDaysCount), openEstimate: openEstimate, doneEstimate: 0, effort: 0, totalEffort: totalEffort };
-		} 
+		}
 
 		for (var effortItemIdx = 0; effortItemIdx < effortContent.length; effortItemIdx++) {
 			totalEffort += effortContent[effortItemIdx].effort;
 			openEstimate = openEstimate - effortContent[effortItemIdx].estimate;
 			statsData[date] = { day: date, date: dateToReceive, totalEstimate: data.estimate, idealEstimate: data.estimate - (averageDayEffort * plannedDaysCount), openEstimate: openEstimate, doneEstimate: effortContent[effortItemIdx].estimate, effort: effortContent[effortItemIdx].effort, totalEffort: totalEffort };
 		}
-	}	
+	}
 
 	var extendedStatistics = {};
 	extendedStatistics.unfinishedItems = data.unfinishedItems;
@@ -237,7 +237,7 @@ function findNearestDate(date, days) {
 		orgNextDate.setDate(orgNextDate.getDate()+1);
 
 		if (compareDate === compareDate)
-			return orgNextDate;		
+			return orgNextDate;
 
 		orgNextDate.setDate(orgNextDate.getDate()-3);
 


### PR DESCRIPTION
This pull request fixes a problem of having the server crash when a card in one of the columns doesn't match the specified regex for gathering the estimate and effective work done.
