### PR TITLE
fixes typo in the overview page for the sprints

### DIFF
--- a/templates/default.template
+++ b/templates/default.template
@@ -62,7 +62,7 @@
 	<h4>Statistics</h4>
 	<p>
 		Total estimate: {{statisticsSummary.totalEstimate}}<br/>
-		Open estimae: {{statisticsSummary.openEstimate}}<br/>
+		Open estimate: {{statisticsSummary.openEstimate}}<br/>
 		Total effort: {{statisticsSummary.effort}}
 	</p>
 
@@ -131,7 +131,7 @@
 		    {
 	           "className": ".main.l2",
 	           "type": "line-dotted",
-	           "data": 
+	           "data":
 	           	[
 		           	{{#effortDaily.data2}}
 			        	{ "x": {{x}}, "y": {{y}} },
@@ -184,7 +184,7 @@
       <div class="alert alert-success">
 	  	<strong>Last generation</strong>: {{generationTime}}
 	  </div>
-      
+
       <hr>
 
   	{{>footer.template}}


### PR DESCRIPTION
Just fixes a minor typo
![typo](https://f.cloud.github.com/assets/542458/540524/4d67e55c-c1ef-11e2-8e90-4297a6e1e72b.png)
