### PR TITLE
better looking error message when trying to add empty lists

### DIFF
--- a/static/trello-burndown.js
+++ b/static/trello-burndown.js
@@ -86,6 +86,14 @@ function SprintViewModel() {
 		owner: this
 	});
 
+	//bind for error message hide/show
+	$(function(){
+	    $("[data-hide]").on("click", function(){
+	        //$(this).closest("." + $(this).attr("data-hide")).hide();
+	        self.isErrorMessageVisible(false);
+	    });
+	});
+
 	// Operations
 	self.addSprint = function() {
 		var dataToSend = ko.toJSON(self.sprint);
@@ -158,9 +166,12 @@ function SprintViewModel() {
 				self.updateSprintDay(data.dates[i].day, data.dates[i].isWorkDay, data.dates[i].include);
 			}
 
-			for (var i = 0; i < data.lists.length; i++) {
-				self.currentList(data.lists[i].name);
-				self.addSprintList();
+			//call addSpringList during load only if there are lists to show
+			if (data.lists.length>0 && data.lists[0].name != "") {
+				for (var i = 0; i < data.lists.length; i++) {
+					self.currentList(data.lists[i].name);
+					self.addSprintList();
+				}
 			}
 
 		}).fail(function(jqXHR, textStatus) {
@@ -194,7 +205,8 @@ function SprintViewModel() {
 
 	self.addSprintList = function() {
 		if (self.currentList() === undefined || self.currentList() == "") {
-			alert("List name can\'t be empty!");
+			self.isErrorMessageVisible(true);
+			self.message("List name can't be empty!");
 			return;
 		}
 		self.sprint.lists.push({ name: self.currentList() });

--- a/templates/addsprint.template
+++ b/templates/addsprint.template
@@ -36,6 +36,17 @@
 		<div class="container">
 			
 			<h2>Add new sprint</h2>
+
+			<div class="alert alert-error" data-bind="visible: isErrorMessageVisible">
+				<button type="button" class="close" data-hide="alert">&times;</button>
+				<strong>Error! </strong><span data-bind="text: message"></span>
+			</div>
+
+			<div class="alert alert-success" data-bind="visible: isInfoMessageVisible">
+				<button type="button" class="close" data-hide="alert">&times;</button>
+				<strong>Well done! </strong><span data-bind="text: message"></span>
+			</div>
+			
 			<form class="form-horizontal" data-bind="submit: addSprint">
 				<div class="control-group">
 					<label class="control-label" for="inputName">Sprint name</label>

--- a/templates/addsprint.template
+++ b/templates/addsprint.template
@@ -43,7 +43,7 @@
 			</div>
 
 			<div class="alert alert-success" data-bind="visible: isInfoMessageVisible">
-				<button type="button" class="close" data-hide="alert">&times;</button>
+				<button type="button" class="close" data-dismiss="alert">&times;</button>
 				<strong>Well done! </strong><span data-bind="text: message"></span>
 			</div>
 			

--- a/templates/editsprint.template
+++ b/templates/editsprint.template
@@ -43,7 +43,7 @@
 			</div>
 
 			<div class="alert alert-success" data-bind="visible: isInfoMessageVisible">
-				<button type="button" class="close" data-hide="alert">&times;</button>
+				<button type="button" class="close" data-dismiss="alert">&times;</button>
 				<strong>Well done! </strong><span data-bind="text: message"></span>
 			</div>
 

--- a/templates/editsprint.template
+++ b/templates/editsprint.template
@@ -38,12 +38,12 @@
 			<h2>Edit sprint</h2>
 			
 			<div class="alert alert-error" data-bind="visible: isErrorMessageVisible">
-				<button type="button" class="close" data-dismiss="alert">&times;</button>
+				<button type="button" class="close" data-hide="alert">&times;</button>
 				<strong>Error! </strong><span data-bind="text: message"></span>
 			</div>
 
 			<div class="alert alert-success" data-bind="visible: isInfoMessageVisible">
-				<button type="button" class="close" data-dismiss="alert">&times;</button>
+				<button type="button" class="close" data-hide="alert">&times;</button>
 				<strong>Well done! </strong><span data-bind="text: message"></span>
 			</div>
 


### PR DESCRIPTION
This is an enhancement to #27:
- use bootstrap alert alert-error instead of js alert()
- the alert can be displayed multiple times: dismiss button doesn't remove it from the page, just hide it

TODO: can be enhanced further by implementing the "hide" also for "alert alert-success" (the binding should call isErrorMessageVisible or isInfoMessageVisible depending on the type of the element whose close button was clicked)
