### PR TITLE
Set the default xMin value for the charts.

### DIFF
--- a/templates/default.template
+++ b/templates/default.template
@@ -108,6 +108,7 @@
 	  var opts = {
 		  "dataFormatX": function (x) { return x; },
 		  "tickFormatX": function (x) { return x; },
+		  "xMin": 0,
 		  "mouseover": function (d, i) {
 		    var pos = $(this).offset();
 		    $(tt).text(d.x + ': ' + d.y)


### PR DESCRIPTION
When the estimate vs. effort charts are initially at 0, they show negative values and the initial line is at the top. This change cleans that up so the charts look better in that initial state.
