### PR TITLE
Set the default yMin for the charts.

### DIFF
--- a/templates/default.template
+++ b/templates/default.template
@@ -109,6 +109,7 @@
 		  "dataFormatX": function (x) { return x; },
 		  "tickFormatX": function (x) { return x; },
 		  "xMin": 0,
+		  "yMin": 0,
 		  "mouseover": function (d, i) {
 		    var pos = $(this).offset();
 		    $(tt).text(d.x + ': ' + d.y)


### PR DESCRIPTION
This is what I actually wanted to set to make the y axis look right when there's no data to show. I can't think of a reason why we would need to have a negative number on either axis, so both the xMin and yMin settings should keep the empty charts clean.
