### PR TITLE
Make [number] and (number) more flexible

### DIFF
--- a/lib/cardstatistics.js
+++ b/lib/cardstatistics.js
@@ -26,8 +26,30 @@ CardStatistics.prototype.generate = function(cards, finishLists, standuptime, ca
 	}
 
 	var reg = /^\[(\d+)\|(\d+(?:\.\d+)?)-(\d+(?:\.\d+)?)\]\s*(.*)$/;
-	var reg_trelloscrum = /^\[(\d+(?:\.\d+)?)\]\s\((\d+(?:\.\d+)?)\)\s*(.*)$/;
-	var reg_trelloscrum_noEffort = /^\((\d+(?:\.\d+)?)\)\s*(.*)$/;
+
+
+	// ^                           # start of the input
+	// (?=                         # start lookahead 1
+	//     [^\[]*                  #     zero or more chars other than '['
+	//     \[                      #     literal '['
+	//     \s*(\d+(?:\.\d+)?)\s*   #     a number, added to match group 1
+	//     ]                       #     literal ']'
+	// )                           # end lookahead 1
+	// (?=                         # start lookahead 2
+	//     [^(]*                   #     zero or more chars other than '('
+	//     \(                      #     literal '('
+	//     \s*(\d+(?:\.\d+)?)\s*   #     a number, added to match group 2 
+	//     \)                      #     literal ')'
+	// )                           # end lookahead 2
+	var reg_trelloscrum = /^(?=[^\[]*\[\s*(\d+(?:\.\d+)?)\s*])(?=[^(]*\(\s*(\d+(?:\.\d+)?)\s*\))(.*)$/;
+
+	// (?=                         # start lookahead 1
+	//     [^(]*                   #     zero or more chars other than '('
+	//     \(                      #     literal '('
+	//     \s*(\d+(?:\.\d+)?)\s*   #     a number, added to match group 1
+	//     \)                      #     literal ')'
+	// )                           # end lookahead 1
+	var reg_trelloscrum_noEffort = /^(?=[^(]*\(\s*(\d+(?:\.\d+)?)\s*\))(.*)$/;
 
 	for (var i = 0; i < cards.length; i++) {
 		var card = cards[i];


### PR DESCRIPTION
The `[number]` and `(number)` have to be formatted quite strictly at the moment:
- `[number]` needs to come before `(number)`
- there cannot be any spaces before, or inside `[number]` and `(number)`
- there must be exactly 1 space in between `[number]` and `(number)`

My proposed pattern will address the points above causing all of these to be parsed identically:

```
"   [1]   (2) title"
"(2)[1]title"
"   [ 1 ]   ( 2.0 ) title"
```

Since I used the match group inside the look-ahead, all of the examples above will have `1` in match group 1 and `2` in match group 2 (even for `"(2)[1]title"`).
